### PR TITLE
Proper way to hide the app from the taskbar on non-macosx platforms

### DIFF
--- a/src/app/main.cljs
+++ b/src/app/main.cljs
@@ -56,7 +56,9 @@
                        :frame false
                        :fullscreenable false
                        :resizable dev?
+                       :skipTaskbar true
                        :transparent true}))
+
 ;; sets image
 (defn set-tray! []
  (let [p (.join path js/__dirname "../../../resources/assets/btc1w.png")]
@@ -82,9 +84,8 @@
   (.setLayoutZoomLevelLimits webframe 0 0))
 
 (defn init []
-  (.hide (.-dock app))
-  (.on app "window-all-closed" #(when-not (= js/process.platform "darwin")
-                                          (.quit app)))
+  (if (= js/process.platform "darwin")
+    (.hide (.-dock app)))
   (.on app "ready" init-browser)
   (do
    (.on app "ready" set-tray!)


### PR DESCRIPTION
Presumably fixes #1 .

Also, there is a proper way to do that for Mac OS X too https://github.com/electron/electron/issues/422#issuecomment-279257496